### PR TITLE
Make /login redirect only happen for client routes

### DIFF
--- a/shared/SinglePageLogin.js
+++ b/shared/SinglePageLogin.js
@@ -47,7 +47,7 @@
       }
     });
 
-    if(this.settings.forceLogin){
+    if(Meteor.isClient && this.settings.forceLogin){
       this.settings.exceptRoutes.push('login','signup','forgot-password', 'logout');
       Router.onRun(function(){
         // above was onBeforeAction


### PR DESCRIPTION
This doesn't make sense for server routes. Plus, you cannot call Meteor.user() from a server route. So, limit it to client only
